### PR TITLE
Cabeçalho: minor debugs

### DIFF
--- a/frontend/src/Tags/Cabecalho.js
+++ b/frontend/src/Tags/Cabecalho.js
@@ -3,6 +3,7 @@ import { Link, NavLink } from 'react-router-dom';
 import logo from '../assets/logo.png';
 import { AiOutlineMenu, AiOutlineClose } from 'react-icons/ai';
 
+
 function Cabecalho () {
 
     const [isMobile, setMobile] = useState(window.innerWidth <= 800)
@@ -19,11 +20,11 @@ function Cabecalho () {
         return () => {
           window.removeEventListener('resize', handleResize)
         };
-    });
+    }, []);
     
-    useEffect(() => {
+    useEffect(() => {       
 
-        if (window.location.href !== 'https://sitegrupoturing.netlify.app/') {
+        if (window.location.pathname !== '/') {
             setAtTop(false)
             return
         } else {


### PR DESCRIPTION
* Verifica se a página ativa é a homepage por meio da rota dessa (`'/'`) e não por sua URL absoluta. Consequentemente, previne quebra do efeito de transparência caso a URL base seja modificada.

* Evita que o *listener* de *resize* seja executado desnecessariamente.